### PR TITLE
OR-37: Create DID Resolve metadata method (without verification rest call)

### DIFF
--- a/src/dids/DidDocumentMetadata.ts
+++ b/src/dids/DidDocumentMetadata.ts
@@ -1,0 +1,17 @@
+/**
+ * Class to model the json that represents the data received in the metadata of a did resolution result
+ * @author Michael Kaufman
+ * Date Last Modified: Apr 10, 2024
+ */
+interface MetadataOption{
+    created?: string;
+    update?: string;
+    method?: string | string[];
+}
+export declare class DidDocumentMetadata{
+    created?: string;
+    update?: string;
+    method?: string | string[];
+    constructor(options:MetadataOption);
+    toJSON(): Record<string, any>;
+}

--- a/src/dids/OracleResolveDriver.ts
+++ b/src/dids/OracleResolveDriver.ts
@@ -1,13 +1,14 @@
-import type {DidResolver, DidResolutionResult} from '@credo-ts/core'
+import {type DidResolver, type DidResolutionResult, DidDocument} from '@credo-ts/core';
 import * as fs from 'fs';
 import axios from 'axios';
+import { JsonTransformer } from '@credo-ts/core';
 
 /**
  * Class to implemented a DID Resolver Driver to be a part of DIF Universal Resolver 
  * @author Michael Kaufman
  * @summary Implements a DID Resolver Driver using previously implemented functions in 
  * Oracle codebase, as well as using functions from Open-Wallet Credo's typescript DID libraries
- * Date Last Modified: Apr 7, 2024
+ * Date Last Modified: Apr 9, 2024
  */
 export class OracleResolveDriver{
     
@@ -131,17 +132,22 @@ export class OracleResolveDriver{
 
     /**
      * Method to resolve a DIDDoc's metadata and use/verify any of its elements before next stage of resolution
-     * @param did DID to be resolved and have verified metadata after resolution
+     * @param diddoc DIDDoc with metadata to be resolved and have verified metadata after resolution
      * @param metadata DIDDoc metadata with elements to use in resolution of did
-     * @returns Promise of DIDDoc resolution after manipulated metadata or error type
+     * @returns Promise of DIDDoc resolution (string) after manipulated metadata or error type
      */
-    public didResolveMetaData(did: string, metadata: any): Promise<any>{
-        //check valid params passed to function
-        //seperate metadata about did or chain validity into specific variables(const)
-        //hit rest api endpoint to verify resolution of metadata elements
-        //figure out api call response
-        //return based on api call response
-        return Promise.resolve();//NOT ACTUAL RETURN STATEMENT, FOR COMPILATION
+    public didResolveMetaData(diddoc: string): Promise<any>{
+        if(diddoc.length <= 0){
+            throw new Error("Invalid params passed to didResolveMetaData method");
+        }
+        try{
+            const diddocObject = JsonTransformer.fromJSON(JSON.parse(diddoc), DidDocument);
+            //hit rest api endpoint to verify resolution of metadata elements
+            //NB: this will be implemented in a later issue
+            return Promise.resolve(JSON.stringify(diddocObject));
+        }catch(err){
+            throw new Error("Unable to parse DIDDoc into JSON in didResolveMetaData method");
+        }
     }
 }
 

--- a/src/dids/OracleResolveDriver.ts
+++ b/src/dids/OracleResolveDriver.ts
@@ -2,13 +2,15 @@ import {type DidResolver, type DidResolutionResult, DidDocument} from '@credo-ts
 import * as fs from 'fs';
 import axios from 'axios';
 import { JsonTransformer } from '@credo-ts/core';
+import { Metadata } from '@credo-ts/core/build/storage/Metadata';
+import {  DidDocumentMetadata } from "./DidDocumentMetadata";
 
 /**
  * Class to implemented a DID Resolver Driver to be a part of DIF Universal Resolver 
  * @author Michael Kaufman
  * @summary Implements a DID Resolver Driver using previously implemented functions in 
  * Oracle codebase, as well as using functions from Open-Wallet Credo's typescript DID libraries
- * Date Last Modified: Apr 9, 2024
+ * Date Last Modified: Apr 10, 2024
  */
 export class OracleResolveDriver{
     
@@ -140,7 +142,7 @@ export class OracleResolveDriver{
             throw new Error("Invalid params passed to didResolveMetaData method");
         }
         try{
-            const diddocMetadataObject = JsonTransformer.fromJSON(JSON.parse(diddocMetadata), DidDocument);
+            const diddocMetadataObject = JsonTransformer.fromJSON(JSON.parse(diddocMetadata),DidDocumentMetadata);
             //hit rest api endpoint to verify resolution of metadata elements
             //NB: this will be implemented in a later issue
             return Promise.resolve(JSON.stringify(diddocMetadataObject));

--- a/src/dids/OracleResolveDriver.ts
+++ b/src/dids/OracleResolveDriver.ts
@@ -7,7 +7,7 @@ import axios from 'axios';
  * @author Michael Kaufman
  * @summary Implements a DID Resolver Driver using previously implemented functions in 
  * Oracle codebase, as well as using functions from Open-Wallet Credo's typescript DID libraries
- * Date Last Modified: Apr 5, 2024
+ * Date Last Modified: Apr 7, 2024
  */
 export class OracleResolveDriver{
     
@@ -127,6 +127,21 @@ export class OracleResolveDriver{
           } catch (err) {
             return Promise.resolve(-1);
           }
+    }
+
+    /**
+     * Method to resolve a DIDDoc's metadata and use/verify any of its elements before next stage of resolution
+     * @param did DID to be resolved and have verified metadata after resolution
+     * @param metadata DIDDoc metadata with elements to use in resolution of did
+     * @returns Promise of DIDDoc resolution after manipulated metadata or error type
+     */
+    public didResolveMetaData(did: string, metadata: any): Promise<any>{
+        //check valid params passed to function
+        //seperate metadata about did or chain validity into specific variables(const)
+        //hit rest api endpoint to verify resolution of metadata elements
+        //figure out api call response
+        //return based on api call response
+        return Promise.resolve();//NOT ACTUAL RETURN STATEMENT, FOR COMPILATION
     }
 }
 

--- a/src/dids/OracleResolveDriver.ts
+++ b/src/dids/OracleResolveDriver.ts
@@ -132,19 +132,18 @@ export class OracleResolveDriver{
 
     /**
      * Method to resolve a DIDDoc's metadata and use/verify any of its elements before next stage of resolution
-     * @param diddoc DIDDoc with metadata to be resolved and have verified metadata after resolution
-     * @param metadata DIDDoc metadata with elements to use in resolution of did
-     * @returns Promise of DIDDoc resolution (string) after manipulated metadata or error type
+     * @param diddoc DIDDoc metadata to be resolved and have verified metadata after resolution
+     * @returns Promise of DIDDoc metadata (string) after manipulated metadata for verification or error type
      */
-    public didResolveMetaData(diddoc: string): Promise<any>{
-        if(diddoc.length <= 0){
+    public didResolveMetaData(diddocMetadata: string): Promise<any>{
+        if(diddocMetadata.length <= 0){
             throw new Error("Invalid params passed to didResolveMetaData method");
         }
         try{
-            const diddocObject = JsonTransformer.fromJSON(JSON.parse(diddoc), DidDocument);
+            const diddocMetadataObject = JsonTransformer.fromJSON(JSON.parse(diddocMetadata), DidDocument);
             //hit rest api endpoint to verify resolution of metadata elements
             //NB: this will be implemented in a later issue
-            return Promise.resolve(JSON.stringify(diddocObject));
+            return Promise.resolve(JSON.stringify(diddocMetadataObject));
         }catch(err){
             throw new Error("Unable to parse DIDDoc into JSON in didResolveMetaData method");
         }

--- a/test/dids/OracleResolveDriver.test.ts
+++ b/test/dids/OracleResolveDriver.test.ts
@@ -7,7 +7,7 @@ declare function assert(value: unknown): asserts value;
 /**
  * File to test methods in oracle Resolve Driver class
  * @author Michael Kaufman
- * Date Last Modified: Apr 9, 2024
+ * Date Last Modified: Apr 10, 2024
  */
 
 
@@ -119,7 +119,7 @@ test('Test 13: Valid Params passed and REST call made, success', ()=>{
 
 test('Test 14: Valid Params passed and REST call not made, failure ', ()=>{
     const driver = new OracleResolveDriver();
-    expect(()=>{driver.didResolveMetaData('{"name":"mockFailJSON"}')}).toThrow();
+    expect(()=>{driver.didResolveMetaData('test')}).toThrow();
 });
 
 test('Test 15: Valid Params passed and REST call made, failure UNIMPLEMENTED', ()=>{

--- a/test/dids/OracleResolveDriver.test.ts
+++ b/test/dids/OracleResolveDriver.test.ts
@@ -1,3 +1,4 @@
+import { DidDocument } from '@credo-ts/core';
 import {OracleResolveDriver} from '../../src/dids/OracleResolveDriver';
 import axios from 'axios';
 declare function assert(value: unknown): asserts value;
@@ -6,7 +7,7 @@ declare function assert(value: unknown): asserts value;
 /**
  * File to test methods in oracle Resolve Driver class
  * @author Michael Kaufman
- * Date Last Modified: Apr 7, 2024
+ * Date Last Modified: Apr 9, 2024
  */
 
 
@@ -104,21 +105,23 @@ test('Test 11: Invalid Config File Passed', () => {
 
 //didResolveMetaData function
 test('Test 12: Invalid DID passed', ()=>{
-    expect(false);//TO BE IMPLEMENTED
+    const driver = new OracleResolveDriver();
+    expect(()=>{driver.didResolveMetaData("")}).toThrow();
 });
 
-test('Test 13: Invalid metadata passed', ()=>{
-    expect(false);//TO BE IMPLEMENTED
+test('Test 13: Valid Params passed and REST call made, success', ()=>{
+    const driver = new OracleResolveDriver();
+    const mockDidDoc: DidDocument = new DidDocument({
+        id: "did:test:123"
+    });
+    expect(()=>{driver.didResolveMetaData(JSON.stringify(mockDidDoc))}).not.toThrow();
 });
 
-test('Test 14: Both Params invalid passed', ()=>{
-    expect(false);//TO BE IMPLEMENTED
+test('Test 14: Valid Params passed and REST call not made, failure ', ()=>{
+    const driver = new OracleResolveDriver();
+    expect(()=>{driver.didResolveMetaData('{"name":"mockFailJSON"}')}).toThrow();
 });
 
-test('Test 15: Valid Params passed and REST call made, success', ()=>{
-    expect(false);//TO BE IMPLEMENTED
-});
-
-test('Test 16: Valid Params passed and REST call made, failure', ()=>{
+test('Test 15: Valid Params passed and REST call made, failure UNIMPLEMENTED', ()=>{
     expect(false);//TO BE IMPLEMENTED
 });

--- a/test/dids/OracleResolveDriver.test.ts
+++ b/test/dids/OracleResolveDriver.test.ts
@@ -6,7 +6,7 @@ declare function assert(value: unknown): asserts value;
 /**
  * File to test methods in oracle Resolve Driver class
  * @author Michael Kaufman
- * Date Last Modified: Apr 5, 2024
+ * Date Last Modified: Apr 7, 2024
  */
 
 
@@ -102,7 +102,23 @@ test('Test 11: Invalid Config File Passed', () => {
 });
 
 
+//didResolveMetaData function
+test('Test 12: Invalid DID passed', ()=>{
+    expect(false);//TO BE IMPLEMENTED
+});
 
+test('Test 13: Invalid metadata passed', ()=>{
+    expect(false);//TO BE IMPLEMENTED
+});
 
+test('Test 14: Both Params invalid passed', ()=>{
+    expect(false);//TO BE IMPLEMENTED
+});
 
+test('Test 15: Valid Params passed and REST call made, success', ()=>{
+    expect(false);//TO BE IMPLEMENTED
+});
 
+test('Test 16: Valid Params passed and REST call made, failure', ()=>{
+    expect(false);//TO BE IMPLEMENTED
+});


### PR DESCRIPTION
Create method that resolves metadata in a hybrid manner; flows like cheqd resolver but utilizes Credo and previously implemented programming interfaces

Create set of unit tests

Document