### PR TITLE
OR-39: W3C Context Push Method

### DIFF
--- a/src/dids/OracleResolveDriver.ts
+++ b/src/dids/OracleResolveDriver.ts
@@ -10,7 +10,7 @@ import {  DidDocumentMetadata } from "./DidDocumentMetadata";
  * @author Michael Kaufman
  * @summary Implements a DID Resolver Driver using previously implemented functions in 
  * Oracle codebase, as well as using functions from Open-Wallet Credo's typescript DID libraries
- * Date Last Modified: Apr 10, 2024
+ * Date Last Modified: Apr 14, 2024
  */
 export class OracleResolveDriver{
     

--- a/src/dids/OracleResolveDriver.ts
+++ b/src/dids/OracleResolveDriver.ts
@@ -167,11 +167,17 @@ export class OracleResolveDriver{
         //access document context
         //push to w3c based on option
         //return boolean after push
+        
         if(didDoc == null || option <= 0 || option >= 4){
             throw new Error('Invalid params passed to didContextPush method');
         }
         didDoc.context = Array.isArray(didDoc.context) ? didDoc.context : [didDoc.context];
+        const canPush: boolean = (typeof didDoc.verificationMethod !== "undefined") && ((didDoc.verificationMethod[0].type == "Ed25519VerificationKey2018") || (didDoc.verificationMethod[0].type == "Ed25519VerificationKey2020")||(didDoc.verificationMethod[0].type == "Ed25519VerificationKey2018")||(didDoc.verificationMethod[0].type == "JsonWebKey2020"));
         let newContextSize = 0;
+        if(!canPush){
+            console.error('Unable to push context to url ${option} in didContextPush method');
+            return false;
+        }
         if(option == 1){
             newContextSize = didDoc.context.push("https://w3id.org/security/suites/ed25519-2020/v1");
         }else if(option == 2){
@@ -179,8 +185,8 @@ export class OracleResolveDriver{
         }else{
             newContextSize = didDoc.context.push("https://w3id.org/security/jwk/v1");
         }
-        if(newContextSize <= 0){
-            throw new Error('Unable to push context to url ${option} in didContextPush method');
+        if(newContextSize<=0){
+            throw new Error("Error when pushing key type to w3c context in didContextPush method");
         }
         didDoc.context = Array.isArray(didDoc.context) ? didDoc.context : [didDoc.context];
         return true;

--- a/src/dids/OracleResolveDriver.ts
+++ b/src/dids/OracleResolveDriver.ts
@@ -167,19 +167,20 @@ export class OracleResolveDriver{
         //access document context
         //push to w3c based on option
         //return boolean after push
-        if(didDoc == null || option <= 0 || option >= 5){
+        if(didDoc == null || option <= 0 || option >= 4){
             throw new Error('Invalid params passed to didContextPush method');
         }
-        if(option == 4){//test case
-            return true;
-        }
         didDoc.context = Array.isArray(didDoc.context) ? didDoc.context : [didDoc.context];
+        let newContextSize = 0;
         if(option == 1){
-            didDoc.context.push("https://w3id.org/security/suites/ed25519-2020/v1");
+            newContextSize = didDoc.context.push("https://w3id.org/security/suites/ed25519-2020/v1");
         }else if(option == 2){
-            didDoc.context.push("https://w3id.org/security/suites/ed25519-2018/v1");
+            newContextSize = didDoc.context.push("https://w3id.org/security/suites/ed25519-2018/v1");
         }else{
-            didDoc.context.push("https://w3id.org/security/jwk/v1");
+            newContextSize = didDoc.context.push("https://w3id.org/security/jwk/v1");
+        }
+        if(newContextSize <= 0){
+            throw new Error('Unable to push context to url ${option} in didContextPush method');
         }
         didDoc.context = Array.isArray(didDoc.context) ? didDoc.context : [didDoc.context];
         return true;

--- a/src/dids/OracleResolveDriver.ts
+++ b/src/dids/OracleResolveDriver.ts
@@ -150,5 +150,24 @@ export class OracleResolveDriver{
             throw new Error("Unable to parse DIDDoc into JSON in didResolveMetaData method");
         }
     }
+
+    /**
+     * Method to do w3c pubkey context pushing
+     * @param didDoc  DIDDoc Resolution Result's DIDDoc field
+     * @param option option of key to context push
+     * @summary Summary of Options:
+     * Option 1: ED25519 2020
+     * Option 2: ED25519 2018
+     * Option 3: JWK 2020
+     * Option 4: Test Push
+     * @returns boolean of success of method
+     */
+    public didContextPush(didDoc: DidDocument, option: number): boolean{
+        //check valid params passed
+        //access document context
+        //push to w3c based on option
+        //return boolean after push
+        return false;//temporary return method
+    }
 }
 

--- a/src/dids/OracleResolveDriver.ts
+++ b/src/dids/OracleResolveDriver.ts
@@ -167,7 +167,22 @@ export class OracleResolveDriver{
         //access document context
         //push to w3c based on option
         //return boolean after push
-        return false;//temporary return method
+        if(didDoc == null || option <= 0 || option >= 5){
+            throw new Error('Invalid params passed to didContextPush method');
+        }
+        if(option == 4){//test case
+            return true;
+        }
+        didDoc.context = Array.isArray(didDoc.context) ? didDoc.context : [didDoc.context];
+        if(option == 1){
+            didDoc.context.push("https://w3id.org/security/suites/ed25519-2020/v1");
+        }else if(option == 2){
+            didDoc.context.push("https://w3id.org/security/suites/ed25519-2018/v1");
+        }else{
+            didDoc.context.push("https://w3id.org/security/jwk/v1");
+        }
+        didDoc.context = Array.isArray(didDoc.context) ? didDoc.context : [didDoc.context];
+        return true;
     }
 }
 

--- a/test/dids/OracleResolveDriver.test.ts
+++ b/test/dids/OracleResolveDriver.test.ts
@@ -7,7 +7,7 @@ declare function assert(value: unknown): asserts value;
 /**
  * File to test methods in oracle Resolve Driver class
  * @author Michael Kaufman
- * Date Last Modified: Apr 10, 2024
+ * Date Last Modified: Apr 14, 2024
  */
 
 

--- a/test/dids/OracleResolveDriver.test.ts
+++ b/test/dids/OracleResolveDriver.test.ts
@@ -129,17 +129,12 @@ test('Test 15: Valid Params passed and REST call made, failure UNIMPLEMENTED', (
 
 //didContextPush function
 test('Test 16: Invalid Option with Valid Diddoc passed, error thrown', ()=>{
-    expect(false);//TO BE IMPLEMENTED
+    const driver = new OracleResolveDriver();
+    expect(()=>{driver.didContextPush(new DidDocument({id: "1"}), 5)}).toThrow();
 });
 
-test('Test 17: Valid Option with Invalid Diddoc passed, error thrown', ()=>{
-    expect(false);//TO BE IMPLEMENTED
-});
-
-test('Test 18: Invalid Option with Invalid Diddoc passed, error thrown', ()=>{
-    expect(false);//TO BE IMPLEMENTED
-});
-
-test('Test 19: Valid (Test) Option with Valid Diddoc passed, boolean returned', ()=>{
-    expect(false);//TO BE IMPLEMENTED
+test('Test 17: Valid (Test) Option with Valid Diddoc passed, boolean returned', ()=>{
+    const driver = new OracleResolveDriver();
+    const result = driver.didContextPush(new DidDocument({id: "1"}), 4);
+    expect(result == true);
 });

--- a/test/dids/OracleResolveDriver.test.ts
+++ b/test/dids/OracleResolveDriver.test.ts
@@ -1,4 +1,4 @@
-import { DidDocument } from '@credo-ts/core';
+import { DidCommV1Service, DidDocument, DidDocumentService, IndyAgentService, VerificationMethod } from '@credo-ts/core';
 import {OracleResolveDriver} from '../../src/dids/OracleResolveDriver';
 import axios from 'axios';
 declare function assert(value: unknown): asserts value;
@@ -13,10 +13,107 @@ declare function assert(value: unknown): asserts value;
 
 
 //fields for mock resoution calls
-var mockDidText = "mockDid";
-var mockQueryText = "mockDirectoryForQuery";
-var mockDid = "did:oracle:test";
-var mockDirectory = "TEST";
+const mockDidText = "mockDid";
+const mockQueryText = "mockDirectoryForQuery";
+const mockDid = "did:oracle:test";
+const mockDirectory = "TEST";
+const didDocumentInstance = new DidDocument({
+    id: 'did:example:123',
+    alsoKnownAs: ['did:example:456'],
+    controller: ['did:example:456'],
+    verificationMethod: [
+      new VerificationMethod({
+        id: 'did:example:123#key-1',
+        type: 'RsaVerificationKey2018',
+        controller: 'did:sov:LjgpST2rjsoxYegQDRm7EL',
+        publicKeyPem: '-----BEGIN PUBLIC X...',
+      }),
+      new VerificationMethod({
+        id: 'did:example:123#key-2',
+        type: 'Ed25519VerificationKey2018',
+        controller: 'did:sov:LjgpST2rjsoxYegQDRm7EL',
+        publicKeyBase58: '-----BEGIN PUBLIC 9...',
+      }),
+      new VerificationMethod({
+        id: 'did:example:123#key-3',
+        type: 'Secp256k1VerificationKey2018',
+        controller: 'did:sov:LjgpST2rjsoxYegQDRm7EL',
+        publicKeyHex: '-----BEGIN PUBLIC A...',
+      }),
+    ],
+    service: [
+      new DidDocumentService({
+        id: 'did:example:123#service-1',
+        type: 'Mediator',
+        serviceEndpoint: 'did:sov:Q4zqM7aXqm7gDQkUVLng9h',
+      }),
+      new IndyAgentService({
+        id: 'did:example:123#service-2',
+        serviceEndpoint: 'did:sov:Q4zqM7aXqm7gDQkUVLng9h',
+        recipientKeys: ['Q4zqM7aXqm7gDQkUVLng9h'],
+        routingKeys: ['Q4zqM7aXqm7gDQkUVLng9h'],
+        priority: 5,
+      }),
+      new DidCommV1Service({
+        id: 'did:example:123#service-3',
+        serviceEndpoint: 'https://agent.com/did-comm',
+        recipientKeys: ['DADEajsDSaksLng9h'],
+        routingKeys: ['DADEajsDSaksLng9h'],
+        priority: 10,
+      }),
+    ],
+    authentication: [
+      'did:example:123#key-1',
+      new VerificationMethod({
+        id: 'did:example:123#authentication-1',
+        type: 'RsaVerificationKey2018',
+        controller: 'did:sov:LjgpST2rjsoxYegQDRm7EL',
+        publicKeyPem: '-----BEGIN PUBLIC A...',
+      }),
+    ],
+    assertionMethod: [
+      'did:example:123#key-1',
+      new VerificationMethod({
+        id: 'did:example:123#assertionMethod-1',
+        type: 'RsaVerificationKey2018',
+        controller: 'did:sov:LjgpST2rjsoxYegQDRm7EL',
+        publicKeyPem: '-----BEGIN PUBLIC A...',
+      }),
+    ],
+    capabilityDelegation: [
+      'did:example:123#key-1',
+      new VerificationMethod({
+        id: 'did:example:123#capabilityDelegation-1',
+        type: 'RsaVerificationKey2018',
+        controller: 'did:sov:LjgpST2rjsoxYegQDRm7EL',
+        publicKeyPem: '-----BEGIN PUBLIC A...',
+      }),
+    ],
+    capabilityInvocation: [
+      'did:example:123#key-1',
+      new VerificationMethod({
+        id: 'did:example:123#capabilityInvocation-1',
+        type: 'RsaVerificationKey2018',
+        controller: 'did:sov:LjgpST2rjsoxYegQDRm7EL',
+        publicKeyPem: '-----BEGIN PUBLIC A...',
+      }),
+    ],
+    keyAgreement: [
+      'did:example:123#key-1',
+      new VerificationMethod({
+        id: 'did:example:123#keyAgreement-1',
+        type: 'RsaVerificationKey2018',
+        controller: 'did:sov:LjgpST2rjsoxYegQDRm7EL',
+        publicKeyPem: '-----BEGIN PUBLIC A...',
+      }),
+      new VerificationMethod({
+        id: 'did:example:123#keyAgreement-1',
+        type: 'Ed25519VerificationKey2018',
+        controller: 'did:sov:LjgpST2rjsoxYegQDRm7EL',
+        publicKeyPem: '-----BEGIN PUBLIC A...',
+      }),
+    ],
+  });//Note: taken from credo-ts/core test repository
 
 
 
@@ -135,6 +232,7 @@ test('Test 16: Invalid Option with Valid Diddoc passed, error thrown', ()=>{
 
 test('Test 17: Valid (Test) Option with Valid Diddoc passed, boolean returned', ()=>{
     const driver = new OracleResolveDriver();
-    const result = driver.didContextPush(new DidDocument({id: "1"}), 4);
+    const result = driver.didContextPush(didDocumentInstance, 2);
+    expect(()=>{driver.didContextPush(didDocumentInstance, 2)}).not.toThrow();
     expect(result == true);
 });

--- a/test/dids/OracleResolveDriver.test.ts
+++ b/test/dids/OracleResolveDriver.test.ts
@@ -18,106 +18,9 @@ const mockDidText = "mockDid";
 const mockQueryText = "mockDirectoryForQuery";
 const mockDid = "did:oracle:test";
 const mockDirectory = "TEST";
-const tempValidDidDocumentStr: string = fs.readFileSync(process.cwd() + "/test/dids/constants/validDid.json", 'utf-8');
-const validDidDocumentInstance = JsonTransformer.fromJSON(JSON.parse(tempValidDidDocumentStr), DidDocument);
-//const validDidDocumentInstance = new DidDocument({
-//    id: 'did:example:123',
-//    alsoKnownAs: ['did:example:456'],
-//    controller: ['did:example:456'],
-//    verificationMethod: [
-//      new VerificationMethod({
-//        id: 'did:example:123#key-1',
-//        type: 'RsaVerificationKey2018',
-//        controller: 'did:sov:LjgpST2rjsoxYegQDRm7EL',
-//        publicKeyPem: '-----BEGIN PUBLIC X...',
-//      }),
-//      new VerificationMethod({
-//        id: 'did:example:123#key-2',
-//        type: 'Ed25519VerificationKey2018',
-//        controller: 'did:sov:LjgpST2rjsoxYegQDRm7EL',
-//        publicKeyBase58: '-----BEGIN PUBLIC 9...',
-//      }),
-//      new VerificationMethod({
-//        id: 'did:example:123#key-3',
-//        type: 'Secp256k1VerificationKey2018',
-//        controller: 'did:sov:LjgpST2rjsoxYegQDRm7EL',
-//        publicKeyHex: '-----BEGIN PUBLIC A...',
-//      }),
-//    ],
-//    service: [
-//      new DidDocumentService({
-//        id: 'did:example:123#service-1',
-//        type: 'Mediator',
-//        serviceEndpoint: 'did:sov:Q4zqM7aXqm7gDQkUVLng9h',
-//      }),
-//      new IndyAgentService({
-//        id: 'did:example:123#service-2',
-//        serviceEndpoint: 'did:sov:Q4zqM7aXqm7gDQkUVLng9h',
-//        recipientKeys: ['Q4zqM7aXqm7gDQkUVLng9h'],
-//        routingKeys: ['Q4zqM7aXqm7gDQkUVLng9h'],
-//        priority: 5,
-//      }),
-//      new DidCommV1Service({
-//        id: 'did:example:123#service-3',
-//        serviceEndpoint: 'https://agent.com/did-comm',
-//        recipientKeys: ['DADEajsDSaksLng9h'],
-//        routingKeys: ['DADEajsDSaksLng9h'],
-//        priority: 10,
-//      }),
-//    ],
-//    authentication: [
-//      'did:example:123#key-1',
-//      new VerificationMethod({
-//        id: 'did:example:123#authentication-1',
-//        type: 'RsaVerificationKey2018',
-//        controller: 'did:sov:LjgpST2rjsoxYegQDRm7EL',
-//        publicKeyPem: '-----BEGIN PUBLIC A...',
-//      }),
-//    ],
-//    assertionMethod: [
-//      'did:example:123#key-1',
-//      new VerificationMethod({
-//        id: 'did:example:123#assertionMethod-1',
-//        type: 'RsaVerificationKey2018',
-//        controller: 'did:sov:LjgpST2rjsoxYegQDRm7EL',
-//        publicKeyPem: '-----BEGIN PUBLIC A...',
-//      }),
-//    ],
-//    capabilityDelegation: [
-//      'did:example:123#key-1',
-//      new VerificationMethod({
-//        id: 'did:example:123#capabilityDelegation-1',
-//        type: 'RsaVerificationKey2018',
-//        controller: 'did:sov:LjgpST2rjsoxYegQDRm7EL',
-//        publicKeyPem: '-----BEGIN PUBLIC A...',
-//      }),
-//    ],
-//    capabilityInvocation: [
-//      'did:example:123#key-1',
-//      new VerificationMethod({
-//        id: 'did:example:123#capabilityInvocation-1',
-//        type: 'RsaVerificationKey2018',
-//        controller: 'did:sov:LjgpST2rjsoxYegQDRm7EL',
-//        publicKeyPem: '-----BEGIN PUBLIC A...',
-//      }),
-//    ],
-//    keyAgreement: [
-//      'did:example:123#key-1',
-//      new VerificationMethod({
-//        id: 'did:example:123#keyAgreement-1',
-//        type: 'RsaVerificationKey2018',
-//        controller: 'did:sov:LjgpST2rjsoxYegQDRm7EL',
-//        publicKeyPem: '-----BEGIN PUBLIC A...',
-//      }),
-//      new VerificationMethod({
-//        id: 'did:example:123#keyAgreement-1',
-//        type: 'Ed25519VerificationKey2018',
-//        controller: 'did:sov:LjgpST2rjsoxYegQDRm7EL',
-//        publicKeyPem: '-----BEGIN PUBLIC A...',
-//      }),
-//    ],
-//  });//Note: taken from credo-ts/core test repository
-//
+const validDidDocumentInstance = JsonTransformer.fromJSON(JSON.parse(fs.readFileSync(process.cwd() + "/test/dids/constants/validDid.json", 'utf-8')), DidDocument);
+const invalidDidDocumentInstance = JsonTransformer.fromJSON(JSON.parse(fs.readFileSync(process.cwd() + "/test/dids/constants/invalidDid.json", 'utf-8')), DidDocument);
+
 
 
 //didResolve function
@@ -238,4 +141,13 @@ test('Test 17: Valid (Test) Option with Valid Diddoc passed, boolean returned', 
     const result = driver.didContextPush(validDidDocumentInstance, 2);
     expect(()=>{driver.didContextPush(validDidDocumentInstance, 2)}).not.toThrow();
     expect(result == true);
+});
+
+
+test('Test 18: Valid (Test) Option with Invalid Diddoc passed, boolean returned', ()=>{
+    const driver = new OracleResolveDriver();
+    const result = driver.didContextPush(invalidDidDocumentInstance, 2);
+    expect(()=>{driver.didContextPush(invalidDidDocumentInstance, 2)}).not.toThrow();
+    //console.log(result);
+    expect(result).toBe(false);
 });

--- a/test/dids/OracleResolveDriver.test.ts
+++ b/test/dids/OracleResolveDriver.test.ts
@@ -1,6 +1,7 @@
-import { DidCommV1Service, DidDocument, DidDocumentService, IndyAgentService, VerificationMethod } from '@credo-ts/core';
+import { DidCommV1Service, DidDocument, DidDocumentService, IndyAgentService, JsonTransformer, VerificationMethod } from '@credo-ts/core';
 import {OracleResolveDriver} from '../../src/dids/OracleResolveDriver';
 import axios from 'axios';
+import * as fs from 'fs';
 declare function assert(value: unknown): asserts value;
 
 
@@ -17,104 +18,106 @@ const mockDidText = "mockDid";
 const mockQueryText = "mockDirectoryForQuery";
 const mockDid = "did:oracle:test";
 const mockDirectory = "TEST";
-const didDocumentInstance = new DidDocument({
-    id: 'did:example:123',
-    alsoKnownAs: ['did:example:456'],
-    controller: ['did:example:456'],
-    verificationMethod: [
-      new VerificationMethod({
-        id: 'did:example:123#key-1',
-        type: 'RsaVerificationKey2018',
-        controller: 'did:sov:LjgpST2rjsoxYegQDRm7EL',
-        publicKeyPem: '-----BEGIN PUBLIC X...',
-      }),
-      new VerificationMethod({
-        id: 'did:example:123#key-2',
-        type: 'Ed25519VerificationKey2018',
-        controller: 'did:sov:LjgpST2rjsoxYegQDRm7EL',
-        publicKeyBase58: '-----BEGIN PUBLIC 9...',
-      }),
-      new VerificationMethod({
-        id: 'did:example:123#key-3',
-        type: 'Secp256k1VerificationKey2018',
-        controller: 'did:sov:LjgpST2rjsoxYegQDRm7EL',
-        publicKeyHex: '-----BEGIN PUBLIC A...',
-      }),
-    ],
-    service: [
-      new DidDocumentService({
-        id: 'did:example:123#service-1',
-        type: 'Mediator',
-        serviceEndpoint: 'did:sov:Q4zqM7aXqm7gDQkUVLng9h',
-      }),
-      new IndyAgentService({
-        id: 'did:example:123#service-2',
-        serviceEndpoint: 'did:sov:Q4zqM7aXqm7gDQkUVLng9h',
-        recipientKeys: ['Q4zqM7aXqm7gDQkUVLng9h'],
-        routingKeys: ['Q4zqM7aXqm7gDQkUVLng9h'],
-        priority: 5,
-      }),
-      new DidCommV1Service({
-        id: 'did:example:123#service-3',
-        serviceEndpoint: 'https://agent.com/did-comm',
-        recipientKeys: ['DADEajsDSaksLng9h'],
-        routingKeys: ['DADEajsDSaksLng9h'],
-        priority: 10,
-      }),
-    ],
-    authentication: [
-      'did:example:123#key-1',
-      new VerificationMethod({
-        id: 'did:example:123#authentication-1',
-        type: 'RsaVerificationKey2018',
-        controller: 'did:sov:LjgpST2rjsoxYegQDRm7EL',
-        publicKeyPem: '-----BEGIN PUBLIC A...',
-      }),
-    ],
-    assertionMethod: [
-      'did:example:123#key-1',
-      new VerificationMethod({
-        id: 'did:example:123#assertionMethod-1',
-        type: 'RsaVerificationKey2018',
-        controller: 'did:sov:LjgpST2rjsoxYegQDRm7EL',
-        publicKeyPem: '-----BEGIN PUBLIC A...',
-      }),
-    ],
-    capabilityDelegation: [
-      'did:example:123#key-1',
-      new VerificationMethod({
-        id: 'did:example:123#capabilityDelegation-1',
-        type: 'RsaVerificationKey2018',
-        controller: 'did:sov:LjgpST2rjsoxYegQDRm7EL',
-        publicKeyPem: '-----BEGIN PUBLIC A...',
-      }),
-    ],
-    capabilityInvocation: [
-      'did:example:123#key-1',
-      new VerificationMethod({
-        id: 'did:example:123#capabilityInvocation-1',
-        type: 'RsaVerificationKey2018',
-        controller: 'did:sov:LjgpST2rjsoxYegQDRm7EL',
-        publicKeyPem: '-----BEGIN PUBLIC A...',
-      }),
-    ],
-    keyAgreement: [
-      'did:example:123#key-1',
-      new VerificationMethod({
-        id: 'did:example:123#keyAgreement-1',
-        type: 'RsaVerificationKey2018',
-        controller: 'did:sov:LjgpST2rjsoxYegQDRm7EL',
-        publicKeyPem: '-----BEGIN PUBLIC A...',
-      }),
-      new VerificationMethod({
-        id: 'did:example:123#keyAgreement-1',
-        type: 'Ed25519VerificationKey2018',
-        controller: 'did:sov:LjgpST2rjsoxYegQDRm7EL',
-        publicKeyPem: '-----BEGIN PUBLIC A...',
-      }),
-    ],
-  });//Note: taken from credo-ts/core test repository
-
+const tempValidDidDocumentStr: string = fs.readFileSync(process.cwd() + "/test/dids/constants/validDid.json", 'utf-8');
+const validDidDocumentInstance = JsonTransformer.fromJSON(JSON.parse(tempValidDidDocumentStr), DidDocument);
+//const validDidDocumentInstance = new DidDocument({
+//    id: 'did:example:123',
+//    alsoKnownAs: ['did:example:456'],
+//    controller: ['did:example:456'],
+//    verificationMethod: [
+//      new VerificationMethod({
+//        id: 'did:example:123#key-1',
+//        type: 'RsaVerificationKey2018',
+//        controller: 'did:sov:LjgpST2rjsoxYegQDRm7EL',
+//        publicKeyPem: '-----BEGIN PUBLIC X...',
+//      }),
+//      new VerificationMethod({
+//        id: 'did:example:123#key-2',
+//        type: 'Ed25519VerificationKey2018',
+//        controller: 'did:sov:LjgpST2rjsoxYegQDRm7EL',
+//        publicKeyBase58: '-----BEGIN PUBLIC 9...',
+//      }),
+//      new VerificationMethod({
+//        id: 'did:example:123#key-3',
+//        type: 'Secp256k1VerificationKey2018',
+//        controller: 'did:sov:LjgpST2rjsoxYegQDRm7EL',
+//        publicKeyHex: '-----BEGIN PUBLIC A...',
+//      }),
+//    ],
+//    service: [
+//      new DidDocumentService({
+//        id: 'did:example:123#service-1',
+//        type: 'Mediator',
+//        serviceEndpoint: 'did:sov:Q4zqM7aXqm7gDQkUVLng9h',
+//      }),
+//      new IndyAgentService({
+//        id: 'did:example:123#service-2',
+//        serviceEndpoint: 'did:sov:Q4zqM7aXqm7gDQkUVLng9h',
+//        recipientKeys: ['Q4zqM7aXqm7gDQkUVLng9h'],
+//        routingKeys: ['Q4zqM7aXqm7gDQkUVLng9h'],
+//        priority: 5,
+//      }),
+//      new DidCommV1Service({
+//        id: 'did:example:123#service-3',
+//        serviceEndpoint: 'https://agent.com/did-comm',
+//        recipientKeys: ['DADEajsDSaksLng9h'],
+//        routingKeys: ['DADEajsDSaksLng9h'],
+//        priority: 10,
+//      }),
+//    ],
+//    authentication: [
+//      'did:example:123#key-1',
+//      new VerificationMethod({
+//        id: 'did:example:123#authentication-1',
+//        type: 'RsaVerificationKey2018',
+//        controller: 'did:sov:LjgpST2rjsoxYegQDRm7EL',
+//        publicKeyPem: '-----BEGIN PUBLIC A...',
+//      }),
+//    ],
+//    assertionMethod: [
+//      'did:example:123#key-1',
+//      new VerificationMethod({
+//        id: 'did:example:123#assertionMethod-1',
+//        type: 'RsaVerificationKey2018',
+//        controller: 'did:sov:LjgpST2rjsoxYegQDRm7EL',
+//        publicKeyPem: '-----BEGIN PUBLIC A...',
+//      }),
+//    ],
+//    capabilityDelegation: [
+//      'did:example:123#key-1',
+//      new VerificationMethod({
+//        id: 'did:example:123#capabilityDelegation-1',
+//        type: 'RsaVerificationKey2018',
+//        controller: 'did:sov:LjgpST2rjsoxYegQDRm7EL',
+//        publicKeyPem: '-----BEGIN PUBLIC A...',
+//      }),
+//    ],
+//    capabilityInvocation: [
+//      'did:example:123#key-1',
+//      new VerificationMethod({
+//        id: 'did:example:123#capabilityInvocation-1',
+//        type: 'RsaVerificationKey2018',
+//        controller: 'did:sov:LjgpST2rjsoxYegQDRm7EL',
+//        publicKeyPem: '-----BEGIN PUBLIC A...',
+//      }),
+//    ],
+//    keyAgreement: [
+//      'did:example:123#key-1',
+//      new VerificationMethod({
+//        id: 'did:example:123#keyAgreement-1',
+//        type: 'RsaVerificationKey2018',
+//        controller: 'did:sov:LjgpST2rjsoxYegQDRm7EL',
+//        publicKeyPem: '-----BEGIN PUBLIC A...',
+//      }),
+//      new VerificationMethod({
+//        id: 'did:example:123#keyAgreement-1',
+//        type: 'Ed25519VerificationKey2018',
+//        controller: 'did:sov:LjgpST2rjsoxYegQDRm7EL',
+//        publicKeyPem: '-----BEGIN PUBLIC A...',
+//      }),
+//    ],
+//  });//Note: taken from credo-ts/core test repository
+//
 
 
 //didResolve function
@@ -232,7 +235,7 @@ test('Test 16: Invalid Option with Valid Diddoc passed, error thrown', ()=>{
 
 test('Test 17: Valid (Test) Option with Valid Diddoc passed, boolean returned', ()=>{
     const driver = new OracleResolveDriver();
-    const result = driver.didContextPush(didDocumentInstance, 2);
-    expect(()=>{driver.didContextPush(didDocumentInstance, 2)}).not.toThrow();
+    const result = driver.didContextPush(validDidDocumentInstance, 2);
+    expect(()=>{driver.didContextPush(validDidDocumentInstance, 2)}).not.toThrow();
     expect(result == true);
 });

--- a/test/dids/OracleResolveDriver.test.ts
+++ b/test/dids/OracleResolveDriver.test.ts
@@ -125,3 +125,21 @@ test('Test 14: Valid Params passed and REST call not made, failure ', ()=>{
 test('Test 15: Valid Params passed and REST call made, failure UNIMPLEMENTED', ()=>{
     expect(false);//TO BE IMPLEMENTED
 });
+
+
+//didContextPush function
+test('Test 16: Invalid Option with Valid Diddoc passed, error thrown', ()=>{
+    expect(false);//TO BE IMPLEMENTED
+});
+
+test('Test 17: Valid Option with Invalid Diddoc passed, error thrown', ()=>{
+    expect(false);//TO BE IMPLEMENTED
+});
+
+test('Test 18: Invalid Option with Invalid Diddoc passed, error thrown', ()=>{
+    expect(false);//TO BE IMPLEMENTED
+});
+
+test('Test 19: Valid (Test) Option with Valid Diddoc passed, boolean returned', ()=>{
+    expect(false);//TO BE IMPLEMENTED
+});

--- a/test/dids/constants/invalidDid.json
+++ b/test/dids/constants/invalidDid.json
@@ -1,0 +1,97 @@
+{
+    "id": "did:example:123",
+    "alsoKnownAs": ["did:example:456"],
+    "controller": ["did:example:456"],
+    "verificationMethod": [
+      {
+        "id": "did:example:123#key-1",
+        "type": "RsaVerificat018",
+        "controller": "did:sov:LjgpST2rjsoxYegQDRm7EL",
+        "publicKeyPem": "-----BEGIN PUBLIC X..."
+      },
+      {
+        "id": "did:example:123#key-2",
+        "type": "Ed2VerificationKey2018",
+        "controller": "did:sov:LjgpST2rjsoxYegQDRm7EL",
+        "publicKeyBase58": "-----BEGIN PUBLIC 9..."
+      },
+      {
+        "id": "did:example:123#key-3",
+        "type": "Secp256kcationKey2018",
+        "controller": "did:sov:LjgpST2rjsoxYegQDRm7EL",
+        "publicKeyHex": "-----BEGIN PUBLIC A..."
+      }
+    ],
+    "service": [
+      {
+        "id": "did:example:123#service-1",
+        "type": "Mediator",
+        "serviceEndpoint": "did:sov:Q4zqM7aXqm7gDQkUVLng9h"
+      },
+      {
+        "id": "did:example:123#service-2",
+        "serviceEndpoint": "did:sov:Q4zqM7aXqm7gDQkUVLng9h",
+        "recipientKeys": ["Q4zqM7aXqm7gDQkUVLng9h"],
+        "routingKeys": ["Q4zqM7aXqm7gDQkUVLng9h"],
+        "priority": 5
+      },
+      {
+        "id": "did:example:123#service-3",
+        "serviceEndpoint": "https://agent.com/did-comm",
+        "recipientKeys": ["DADEajsDSaksLng9h"],
+        "routingKeys": ["DADEajsDSaksLng9h"],
+        "priority": 10
+      }
+    ],
+    "authentication": [
+      "did:example:123#key-1",
+      {
+        "id": "did:example:123#authentication-1",
+        "type": "RsaVerificationKey2018",
+        "controller": "did:sov:LjgpST2rjsoxYegQDRm7EL",
+        "publicKeyPem": "-----BEGIN PUBLIC A..."
+      }
+    ],
+    "assertionMethod": [
+      "did:example:123#key-1",
+      {
+        "id": "did:example:123#assertionMethod-1",
+        "type": "RsaVerificationKey2018",
+        "controller": "did:sov:LjgpST2rjsoxYegQDRm7EL",
+        "publicKeyPem": "-----BEGIN PUBLIC A..."
+      }
+    ],
+    "capabilityDelegation": [
+      "did:example:123#key-1",
+      {
+        "id": "did:example:123#capabilityDelegation-1",
+        "type": "RsaVerificationKey2018",
+        "controller": "did:sov:LjgpST2rjsoxYegQDRm7EL",
+        "publicKeyPem": "-----BEGIN PUBLIC A..."
+      }
+    ],
+    "capabilityInvocation": [
+      "did:example:123#key-1",
+      {
+        "id": "did:example:123#capabilityInvocation-1",
+        "type": "RsaVerificationKey2018",
+        "controller": "did:sov:LjgpST2rjsoxYegQDRm7EL",
+        "publicKeyPem": "-----BEGIN PUBLIC A..."
+      }
+    ],
+    "keyAgreement": [
+      "did:example:123#key-1",
+      {
+        "id": "did:example:123#keyAgreement-1",
+        "type": "RsaVerificationKey2018",
+        "controller": "did:sov:LjgpST2rjsoxYegQDRm7EL",
+        "publicKeyPem": "-----BEGIN PUBLIC A..."
+      },
+      {
+        "id": "did:example:123#keyAgreement-1",
+        "type": "Ed25519VerificationKey2018",
+        "controller": "did:sov:LjgpST2rjsoxYegQDRm7EL",
+        "publicKeyPem": "-----BEGIN PUBLIC A..."
+      }
+    ]
+  }

--- a/test/dids/constants/invalidDid.json
+++ b/test/dids/constants/invalidDid.json
@@ -1,4 +1,7 @@
 {
+  "@context": [
+    "https://www.w3.org/ns/did/v1"
+    ],
     "id": "did:example:123",
     "alsoKnownAs": ["did:example:456"],
     "controller": ["did:example:456"],

--- a/test/dids/constants/validDid.json
+++ b/test/dids/constants/validDid.json
@@ -1,0 +1,97 @@
+{
+    "id": "did:example:123",
+    "alsoKnownAs": ["did:example:456"],
+    "controller": ["did:example:456"],
+    "verificationMethod": [
+      {
+        "id": "did:example:123#key-1",
+        "type": "RsaVerificationKey2018",
+        "controller": "did:sov:LjgpST2rjsoxYegQDRm7EL",
+        "publicKeyPem": "-----BEGIN PUBLIC X..."
+      },
+      {
+        "id": "did:example:123#key-2",
+        "type": "Ed25519VerificationKey2018",
+        "controller": "did:sov:LjgpST2rjsoxYegQDRm7EL",
+        "publicKeyBase58": "-----BEGIN PUBLIC 9..."
+      },
+      {
+        "id": "did:example:123#key-3",
+        "type": "Secp256k1VerificationKey2018",
+        "controller": "did:sov:LjgpST2rjsoxYegQDRm7EL",
+        "publicKeyHex": "-----BEGIN PUBLIC A..."
+      }
+    ],
+    "service": [
+      {
+        "id": "did:example:123#service-1",
+        "type": "Mediator",
+        "serviceEndpoint": "did:sov:Q4zqM7aXqm7gDQkUVLng9h"
+      },
+      {
+        "id": "did:example:123#service-2",
+        "serviceEndpoint": "did:sov:Q4zqM7aXqm7gDQkUVLng9h",
+        "recipientKeys": ["Q4zqM7aXqm7gDQkUVLng9h"],
+        "routingKeys": ["Q4zqM7aXqm7gDQkUVLng9h"],
+        "priority": 5
+      },
+      {
+        "id": "did:example:123#service-3",
+        "serviceEndpoint": "https://agent.com/did-comm",
+        "recipientKeys": ["DADEajsDSaksLng9h"],
+        "routingKeys": ["DADEajsDSaksLng9h"],
+        "priority": 10
+      }
+    ],
+    "authentication": [
+      "did:example:123#key-1",
+      {
+        "id": "did:example:123#authentication-1",
+        "type": "RsaVerificationKey2018",
+        "controller": "did:sov:LjgpST2rjsoxYegQDRm7EL",
+        "publicKeyPem": "-----BEGIN PUBLIC A..."
+      }
+    ],
+    "assertionMethod": [
+      "did:example:123#key-1",
+      {
+        "id": "did:example:123#assertionMethod-1",
+        "type": "RsaVerificationKey2018",
+        "controller": "did:sov:LjgpST2rjsoxYegQDRm7EL",
+        "publicKeyPem": "-----BEGIN PUBLIC A..."
+      }
+    ],
+    "capabilityDelegation": [
+      "did:example:123#key-1",
+      {
+        "id": "did:example:123#capabilityDelegation-1",
+        "type": "RsaVerificationKey2018",
+        "controller": "did:sov:LjgpST2rjsoxYegQDRm7EL",
+        "publicKeyPem": "-----BEGIN PUBLIC A..."
+      }
+    ],
+    "capabilityInvocation": [
+      "did:example:123#key-1",
+      {
+        "id": "did:example:123#capabilityInvocation-1",
+        "type": "RsaVerificationKey2018",
+        "controller": "did:sov:LjgpST2rjsoxYegQDRm7EL",
+        "publicKeyPem": "-----BEGIN PUBLIC A..."
+      }
+    ],
+    "keyAgreement": [
+      "did:example:123#key-1",
+      {
+        "id": "did:example:123#keyAgreement-1",
+        "type": "RsaVerificationKey2018",
+        "controller": "did:sov:LjgpST2rjsoxYegQDRm7EL",
+        "publicKeyPem": "-----BEGIN PUBLIC A..."
+      },
+      {
+        "id": "did:example:123#keyAgreement-1",
+        "type": "Ed25519VerificationKey2018",
+        "controller": "did:sov:LjgpST2rjsoxYegQDRm7EL",
+        "publicKeyPem": "-----BEGIN PUBLIC A..."
+      }
+    ]
+  }

--- a/test/dids/constants/validDid.json
+++ b/test/dids/constants/validDid.json
@@ -1,4 +1,7 @@
 {
+  "@context": [
+  "https://www.w3.org/ns/did/v1"
+  ],
     "id": "did:example:123",
     "alsoKnownAs": ["did:example:456"],
     "controller": ["did:example:456"],
@@ -6,7 +9,7 @@
       {
         "id": "did:example:123#key-2",
         "type": "Ed25519VerificationKey2018",
-        "controller": "did:sov:LjgpST2rjsoxYegQDRm7EL",
+        "controller": "did:orcl:LjgpST2rjsoxYegQDRm7EL",
         "publicKeyBase58": "-----BEGIN PUBLIC 9..."
       }
     ],

--- a/test/dids/constants/validDid.json
+++ b/test/dids/constants/validDid.json
@@ -4,22 +4,10 @@
     "controller": ["did:example:456"],
     "verificationMethod": [
       {
-        "id": "did:example:123#key-1",
-        "type": "RsaVerificationKey2018",
-        "controller": "did:sov:LjgpST2rjsoxYegQDRm7EL",
-        "publicKeyPem": "-----BEGIN PUBLIC X..."
-      },
-      {
         "id": "did:example:123#key-2",
         "type": "Ed25519VerificationKey2018",
         "controller": "did:sov:LjgpST2rjsoxYegQDRm7EL",
         "publicKeyBase58": "-----BEGIN PUBLIC 9..."
-      },
-      {
-        "id": "did:example:123#key-3",
-        "type": "Secp256k1VerificationKey2018",
-        "controller": "did:sov:LjgpST2rjsoxYegQDRm7EL",
-        "publicKeyHex": "-----BEGIN PUBLIC A..."
       }
     ],
     "service": [


### PR DESCRIPTION
Create a method that handles W3C and other standard context pushing in switch statment; follows similar design to context pushing conditionals in cheqd resolver

Create mock context for test sets

Create set of unit tests

Document